### PR TITLE
Fix: Deprecated: mb_convert_encoding() in PHP 8.2

### DIFF
--- a/pocketproxy.php
+++ b/pocketproxy.php
@@ -533,7 +533,7 @@ if (stripos($contentType, "text/html") !== false) {
 	//Attempt to normalize character encoding.
 	$detectedEncoding = mb_detect_encoding($responseBody, "UTF-8, ISO-8859-1");
 	if ($detectedEncoding) {
-		$responseBody = mb_convert_encoding($responseBody, "HTML-ENTITIES", $detectedEncoding);
+		$responseBody = htmlspecialchars_decode($responseBody);
 	}
 	if(empty($responseBody)){
 		$responseBody = " ";


### PR DESCRIPTION
When running under PHP 8.2 this error is thrown:
`Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in /var/www/html/index.php on line 536`

This fixes that error.